### PR TITLE
fix(dispatch): send split-EDI outputs instead of the original file

### DIFF
--- a/dispatch/pipeline/splitter.py
+++ b/dispatch/pipeline/splitter.py
@@ -606,12 +606,26 @@ class EDISplitterStep(ErrorRecordingMixin):
         )
         return filtered_files
 
-    def execute(self, file_path: str, folder: dict) -> list[str]:
+    def execute(
+        self,
+        file_path: str,
+        folder: dict,
+        output_dir: str | None = None,
+    ) -> list[str]:
         """Execute split step (wrapper for pipeline compatibility).
+
+        Note:
+            Prefer the ``split()`` interface when the caller needs the split
+            outputs to outlive this call (e.g. to send them). This wrapper
+            returns paths into a caller-owned directory; it never deletes
+            the outputs it produces.
 
         Args:
             file_path: Path to the file to split
             folder: Folder configuration dictionary
+            output_dir: Optional caller-owned directory for split outputs.
+                When omitted, a fresh temp dir is created and left for the
+                caller to clean up.
 
         Returns:
             List of output file paths
@@ -619,8 +633,7 @@ class EDISplitterStep(ErrorRecordingMixin):
         """
         import tempfile
 
+        temp_dir = output_dir or tempfile.mkdtemp(prefix="edi_split_")
         upc_dict = folder.get("upc_dict", {})
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            result = self.split(file_path, temp_dir, folder, upc_dict)
-            return [f[0] for f in result.files]
+        result = self.split(file_path, temp_dir, folder, upc_dict)
+        return [f[0] for f in result.files]

--- a/dispatch/services/file_processor.py
+++ b/dispatch/services/file_processor.py
@@ -11,7 +11,14 @@ through the validation, splitting, conversion, and sending pipeline. It handles:
 import os
 import shutil
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Type-checking only: importing dispatch.pipeline at module level creates
+    # a circular import (dispatch.results -> dispatch.services ->
+    # file_processor -> dispatch.pipeline -> dispatch.results). The runtime
+    # imports live inside _run_splitting. See docs/IMPORT_ARCHITECTURE.md.
+    from dispatch.pipeline.splitter import SplitterResult
 
 from core.structured_logging import (
     get_logger,
@@ -294,7 +301,7 @@ class FileProcessor:
 
         # Run splitting
         split_start = time.time()
-        split_skipped = self._run_splitting(
+        split_outcome = self._run_splitting(
             current_file=current_file,
             _file_path=file_path,
             file_basename=file_basename,
@@ -303,16 +310,44 @@ class FileProcessor:
             _run_log=run_log,
         )
         split_duration = int((time.time() - split_start) * 1000)
-        if self._audit_logger and split_skipped:
+        if self._audit_logger:
+            split_output = (
+                split_outcome.files[0][0]
+                if split_outcome.files and split_outcome.files[0][0] != current_file
+                else None
+            )
             self._audit_logger.log_step(
                 correlation_id=correlation_id,
                 folder_id=folder_id,
                 file_name=file_name,
                 step="split",
-                status="skipped",
+                status="success" if split_outcome.was_split else "skipped",
                 duration_ms=split_duration,
                 input_path=current_file,
+                output_path=split_output,
             )
+
+        # When the file was split, convert and send each split output instead
+        # of the original (which may be a multi-invoice file the receiver
+        # cannot process as-is). Split outputs live in a temp dir tracked on
+        # the context and are cleaned up by _cleanup_temp_artifacts.
+        if self._handle_split_outputs(
+            split_outcome=split_outcome,
+            current_file=current_file,
+            file_path=file_path,
+            context=context,
+            result=result,
+            run_log=run_log,
+            correlation_id=correlation_id,
+            folder_id=folder_id,
+            file_name=file_name,
+        ):
+            return
+
+        # Without a split, the splitter may still have produced a single
+        # category-filtered copy — send that instead of the original input.
+        if split_outcome.files and split_outcome.files[0][0] != current_file:
+            current_file = split_outcome.files[0][0]
 
         # Run conversion
         convert_start = time.time()
@@ -539,8 +574,12 @@ class FileProcessor:
         context: ProcessingContext,
         result: FileResult,
         _run_log: RunLog | None,
-    ) -> bool:
+    ) -> "SplitterResult":
         """Run splitting step of the pipeline.
+
+        Split outputs are written to a temp directory tracked on the
+        processing context so the files remain on disk until they are sent;
+        cleanup happens in ``_cleanup_temp_artifacts``.
 
         Args:
             current_file: Current file path
@@ -551,29 +590,149 @@ class FileProcessor:
             run_log: Run log
 
         Returns:
-            True if processing should stop (split occurred)
+            SplitterResult describing the split outcome. ``was_split`` is
+            True when the input was split into multiple outputs; ``files``
+            holds ``(path, prefix, suffix)`` tuples for the outputs.
 
         """
+        # Function-local imports: importing dispatch.pipeline at module level
+        # creates a circular import (dispatch.results -> dispatch.services ->
+        # file_processor -> dispatch.pipeline -> dispatch.results).
+        from dispatch.pipeline.splitter import SplitterResult
+        from dispatch.pipeline.temp_dir_utils import create_pipeline_temp_dir
+
         if not self.splitter_step:
-            return False
+            return SplitterResult(files=[], was_split=False)
+
+        temp_dir, _ = create_pipeline_temp_dir(
+            "edi_split", context.effective_folder, context
+        )
 
         try:
-            split_output = self.splitter_step.execute(
+            split_result: SplitterResult = self.splitter_step.split(
                 current_file,
+                temp_dir,
                 context.effective_folder,
+                context.upc_dict or {},
             )
-            # Returns list[str] of output paths
-            was_split = bool(split_output)
-            if was_split:
-                logger.info(
-                    "File %s was split into %d files", file_basename, len(split_output)
-                )
-                return True
-            return False
         except Exception as e:
             logger.exception("Splitting error for %s: %s", file_basename, e)
             result.errors.append(f"Splitting error: {e}")
+            return SplitterResult(files=[], was_split=False, errors=[str(e)])
+
+        if split_result.was_split:
+            logger.info(
+                "File %s was split into %d files",
+                file_basename,
+                len(split_result.files),
+            )
+        else:
+            logger.debug(
+                "File %s was not split (was_filtered=%s)",
+                file_basename,
+                split_result.was_filtered,
+            )
+        return split_result
+
+    def _handle_split_outputs(
+        self,
+        split_outcome: "SplitterResult",
+        current_file: str,
+        file_path: str,
+        context: ProcessingContext,
+        result: FileResult,
+        run_log: RunLog | None,
+        *,
+        correlation_id: str,
+        folder_id: int,
+        file_name: str,
+    ) -> bool:
+        """Send split outputs when a split occurred, logging the send step.
+
+        Returns:
+            True when the file was split and its outputs were sent (the
+            pipeline should stop); False when no split occurred.
+
+        """
+        import time
+
+        if not split_outcome.was_split:
             return False
+
+        send_start = time.time()
+        self._send_split_files(
+            split_files=split_outcome.files or [(current_file, "", "")],
+            context=context,
+            result=result,
+            run_log=run_log,
+        )
+        send_duration = int((time.time() - send_start) * 1000)
+        if self._audit_logger:
+            send_status = "success" if result.sent else "failure"
+            self._audit_logger.log_step(
+                correlation_id=correlation_id,
+                folder_id=folder_id,
+                file_name=file_name,
+                step="send",
+                status=send_status,
+                duration_ms=send_duration,
+                input_path=file_path,
+            )
+        return True
+
+    def _send_split_files(
+        self,
+        split_files: list[tuple[str, str, str]],
+        context: ProcessingContext,
+        result: FileResult,
+        run_log: RunLog | None,
+    ) -> None:
+        """Convert (if enabled) and send each split output file.
+
+        Aggregates the send outcome across all split files into
+        ``result.sent``. Conversion is applied per split file when a
+        converter step is configured and validation passed.
+
+        Args:
+            split_files: List of (path, prefix, suffix) split outputs
+            context: Processing context
+            result: File result
+            run_log: Run log
+
+        """
+        all_sends_succeeded = True
+        for split_path, _prefix, _suffix in split_files:
+            pipeline_file = split_path
+            if self.converter_step and result.validated:
+                try:
+                    converted_file = self.converter_step.execute(
+                        pipeline_file,
+                        context.effective_folder,
+                        context.settings,
+                        context.upc_dict,
+                        context=context,
+                    )
+                except Exception as e:
+                    logger.exception(
+                        "Conversion error for split file %s: %s", pipeline_file, e
+                    )
+                    converted_file = None
+                if converted_file:
+                    result.converted = True
+                    pipeline_file = converted_file
+
+            send_ok = self._send_file(
+                current_file=pipeline_file,
+                file_path=pipeline_file,
+                file_basename=os.path.basename(pipeline_file),
+                context=context,
+                result=result,
+                run_log=run_log,
+            )
+            if not send_ok:
+                all_sends_succeeded = False
+
+        result.sent = all_sends_succeeded
 
     def _send_file(
         self,
@@ -583,7 +742,7 @@ class FileProcessor:
         context: ProcessingContext,
         result: FileResult,
         run_log: RunLog | None,
-    ) -> None:
+    ) -> bool:
         """Send file to enabled backends.
 
         Args:
@@ -594,6 +753,9 @@ class FileProcessor:
             result: File result
             run_log: Run log
 
+        Returns:
+            True if the send succeeded
+
         """
         enabled_backends = self.send_manager.get_enabled_backends(
             context.effective_folder
@@ -601,7 +763,7 @@ class FileProcessor:
         if not enabled_backends:
             result.sent = False
             result.errors.append("No backends enabled")
-            return
+            return False
 
         # Apply file rename if configured
         from dispatch.file_utils import apply_file_rename as _ar
@@ -629,9 +791,10 @@ class FileProcessor:
                 current_file=current_file,
                 _run_log=run_log,
             )
-            return
+            return result.sent
 
         self._log_success(file_basename, file_path, run_log)
+        return result.sent
 
     def _send_to_backends(
         self,

--- a/tests/unit/dispatch_tests/test_file_processor.py
+++ b/tests/unit/dispatch_tests/test_file_processor.py
@@ -19,7 +19,12 @@ import pytest
 
 from dispatch.interfaces import ErrorHandlerInterface, FileSystemInterface
 from dispatch.pipeline.interfaces import PipelineStep
-from dispatch.send_manager import SendManager
+from dispatch.pipeline.splitter import (
+    EDISplitterStep,
+    SplitterInterface,
+    SplitterResult,
+)
+from dispatch.send_manager import MockBackend, SendManager
 from dispatch.services.file_processor import (
     FileProcessor,
     FileResult,
@@ -416,21 +421,24 @@ class TestRunValidation:
 class TestRunSplitting:
     """Tests for _run_splitting method."""
 
+    def _make_context(self):
+        return ProcessingContext(
+            folder={},
+            effective_folder={},
+            settings={},
+            upc_dict={},
+        )
+
     def test_splitting_no_step(self):
-        """Test splitting with no splitter step returns False."""
+        """Test splitting with no splitter step returns a no-split outcome."""
         send_manager = MagicMock(spec=SendManager)
         error_handler = MagicMock(spec=ErrorHandlerInterface)
         processor = FileProcessor(send_manager, error_handler)
 
         result = FileResult(file_name="test.edi", checksum="")
-        context = ProcessingContext(
-            folder={},
-            effective_folder={},
-            settings={},
-            upc_dict={},
-        )
+        context = self._make_context()
 
-        was_split = processor._run_splitting(
+        split_outcome = processor._run_splitting(
             current_file="/path/to/file.edi",
             _file_path="/path/to/file.edi",
             file_basename="file.edi",
@@ -439,26 +447,22 @@ class TestRunSplitting:
             _run_log=None,
         )
 
-        assert not was_split
+        assert not split_outcome.was_split
+        assert split_outcome.files == []
 
     def test_splitting_no_output(self):
-        """Test splitting with no output returns False."""
+        """Test splitting with no output returns a no-split outcome."""
         send_manager = MagicMock(spec=SendManager)
         error_handler = MagicMock(spec=ErrorHandlerInterface)
-        splitter = MagicMock(spec=PipelineStep)
-        splitter.execute.return_value = []
+        splitter = MagicMock(spec=SplitterInterface)
+        splitter.split.return_value = SplitterResult(files=[], was_split=False)
 
         processor = FileProcessor(send_manager, error_handler, splitter_step=splitter)
 
         result = FileResult(file_name="test.edi", checksum="")
-        context = ProcessingContext(
-            folder={},
-            effective_folder={},
-            settings={},
-            upc_dict={},
-        )
+        context = self._make_context()
 
-        was_split = processor._run_splitting(
+        split_outcome = processor._run_splitting(
             current_file="/path/to/file.edi",
             _file_path="/path/to/file.edi",
             file_basename="file.edi",
@@ -467,26 +471,29 @@ class TestRunSplitting:
             _run_log=None,
         )
 
-        assert not was_split
+        assert not split_outcome.was_split
+        assert split_outcome.files == []
+        processor._cleanup_temp_artifacts(context)
 
     def test_splitting_with_output(self):
-        """Test splitting with output returns True."""
+        """Test splitting with output reports was_split with the split files."""
         send_manager = MagicMock(spec=SendManager)
         error_handler = MagicMock(spec=ErrorHandlerInterface)
-        splitter = MagicMock(spec=PipelineStep)
-        splitter.execute.return_value = ["/path/to/output1.edi", "/path/to/output2.edi"]
+        splitter = MagicMock(spec=SplitterInterface)
+        splitter.split.return_value = SplitterResult(
+            files=[
+                ("/path/to/output1.edi", "A_", ".edi"),
+                ("/path/to/output2.edi", "B_", ".edi"),
+            ],
+            was_split=True,
+        )
 
         processor = FileProcessor(send_manager, error_handler, splitter_step=splitter)
 
         result = FileResult(file_name="test.edi", checksum="")
-        context = ProcessingContext(
-            folder={},
-            effective_folder={},
-            settings={},
-            upc_dict={},
-        )
+        context = self._make_context()
 
-        was_split = processor._run_splitting(
+        split_outcome = processor._run_splitting(
             current_file="/path/to/file.edi",
             _file_path="/path/to/file.edi",
             file_basename="file.edi",
@@ -495,7 +502,400 @@ class TestRunSplitting:
             _run_log=None,
         )
 
-        assert was_split
+        assert split_outcome.was_split
+        assert [f[0] for f in split_outcome.files] == [
+            "/path/to/output1.edi",
+            "/path/to/output2.edi",
+        ]
+        # The splitter receives the caller's UPC dictionary, not an empty one.
+        splitter.split.assert_called_once()
+        assert splitter.split.call_args.args[3] == {}
+        processor._cleanup_temp_artifacts(context)
+
+    def test_splitting_passes_upc_dict_to_splitter(self):
+        """The UPC dictionary is threaded into the splitter call."""
+        send_manager = MagicMock(spec=SendManager)
+        error_handler = MagicMock(spec=ErrorHandlerInterface)
+        splitter = MagicMock(spec=SplitterInterface)
+        splitter.split.return_value = SplitterResult(files=[], was_split=False)
+
+        processor = FileProcessor(send_manager, error_handler, splitter_step=splitter)
+
+        result = FileResult(file_name="test.edi", checksum="")
+        context = ProcessingContext(
+            folder={},
+            effective_folder={},
+            settings={},
+            upc_dict={"123456": ("cat1", "upc_pack", "upc_case")},
+        )
+
+        processor._run_splitting(
+            current_file="/path/to/file.edi",
+            _file_path="/path/to/file.edi",
+            file_basename="file.edi",
+            context=context,
+            result=result,
+            _run_log=None,
+        )
+
+        splitter.split.assert_called_once()
+        assert splitter.split.call_args.args[3] == {
+            "123456": ("cat1", "upc_pack", "upc_case")
+        }
+        processor._cleanup_temp_artifacts(context)
+
+
+class TestSplitPipelineEndToEnd:
+    """End-to-end: split outputs — not the original — are what get sent."""
+
+    # Two A records (distinct invoices) each followed by a B record so the
+    # real EDISplitter produces one output file per invoice.
+    _TWO_INVOICE_EDI = (
+        "AVENDOR00000000010101250000100000\r\n"
+        "B01234567890Test Item Description    1234560001000100000100010991001000000\r\n"
+        "AVENDOR00000000020201250000100000\r\n"
+        "B01234567890Test Item Description    1234560001000100000100010991001000000\r\n"
+    )
+
+    def _build_processor(self, converter_step=None, backend=None):
+        backend = backend or MockBackend()
+        send_manager = SendManager(backends={"mock": backend})
+        error_handler = MagicMock(spec=ErrorHandlerInterface)
+        processor = FileProcessor(
+            send_manager=send_manager,
+            error_handler=error_handler,
+            splitter_step=EDISplitterStep(),
+            converter_step=converter_step,
+        )
+        return processor, backend
+
+    def _write_input(self, tmp_path, name="multi_invoice.edi"):
+        input_file = tmp_path / name
+        input_file.write_text(self._TWO_INVOICE_EDI, encoding="utf-8")
+        return str(input_file)
+
+    def test_split_outputs_are_sent_instead_of_original(self, tmp_path):
+        """Each per-invoice split file reaches the backend, never the original."""
+        input_file = self._write_input(tmp_path)
+        processor, backend = self._build_processor(backend=_SnapshotBackend())
+
+        folder = {
+            "id": 1,
+            "alias": "split-test",
+            "folder_name": str(tmp_path),
+            "split_edi": True,
+        }
+        result = processor.process_file(
+            file_path=input_file,
+            folder=folder,
+            upc_dict={},
+            run_log=None,
+        )
+
+        assert (
+            result.sent is True
+        ), f"expected split files sent, errors: {result.errors}"
+        sent_files = [call[2] for call in backend.send_calls]
+        assert len(sent_files) == 2, f"expected 2 split files, got {sent_files}"
+        assert input_file not in sent_files, "original file must not be sent"
+        for sent_path in sent_files:
+            # Split outputs live in the pipeline temp dir, not the source dir.
+            assert os.path.dirname(sent_path) != str(tmp_path)
+            assert os.path.basename(sent_path).endswith(".inv"), sent_path
+        assert len(set(sent_files)) == 2, "split files must be distinct outputs"
+        # Files exist (and are readable) at send time.
+        assert len(backend.snapshots) == 2, backend.snapshots
+        assert all(content for _, content in backend.snapshots), backend.snapshots
+
+    def test_conversion_applies_to_each_split_file(self, tmp_path):
+        """Each split file is converted before it is sent."""
+        input_file = self._write_input(tmp_path)
+        converter = _RecordingConverter()
+        processor, backend = self._build_processor(
+            converter_step=converter, backend=_SnapshotBackend()
+        )
+
+        folder = {
+            "id": 2,
+            "alias": "split-convert",
+            "folder_name": str(tmp_path),
+            "split_edi": True,
+        }
+        result = processor.process_file(
+            file_path=input_file,
+            folder=folder,
+            upc_dict={},
+            run_log=None,
+        )
+
+        assert (
+            result.sent is True
+        ), f"expected converted split files sent: {result.errors}"
+        assert result.converted is True
+        assert (
+            len(converter.inputs) == 2
+        ), f"expected 2 conversions, got {converter.inputs}"
+        assert input_file not in converter.inputs
+        sent_files = [call[2] for call in backend.send_calls]
+        assert len(sent_files) == 2
+        assert all(path.endswith(".csv") for path in sent_files)
+        # The converted files exist (and are readable) at send time.
+        assert len(backend.snapshots) == 2, backend.snapshots
+        assert all(content == b"converted" for _, content in backend.snapshots)
+
+    def test_split_disabled_sends_original(self, tmp_path):
+        """Without split_edi, the original file is sent unchanged."""
+        input_file = self._write_input(tmp_path)
+        processor, backend = self._build_processor()
+
+        folder = {
+            "id": 3,
+            "alias": "no-split",
+            "folder_name": str(tmp_path),
+            "split_edi": False,
+        }
+        result = processor.process_file(
+            file_path=input_file,
+            folder=folder,
+            upc_dict={},
+            run_log=None,
+        )
+
+        assert result.sent is True, f"expected original sent, errors: {result.errors}"
+        sent_files = [call[2] for call in backend.send_calls]
+        assert sent_files == [input_file]
+
+    # --- Category filtering without splitting (split_edi=False) ------------
+
+    def _write_category_input(self, tmp_path, name="filter_me.edi"):
+        """Two invoices: inv 1 has a cat1 and a cat2 line item, inv 2 only cat2."""
+        from core.edi.edi_parser import build_a_record, build_b_record
+
+        a1 = build_a_record("VENDOR", "0000000101", "012500", "0000100000")
+        b1_cat1 = build_b_record(
+            "01234567890",
+            "Cat One Item".ljust(25),
+            "123456",
+            "000100",
+            "01",
+            "000100",
+            "00010",
+            "00109",
+        )
+        b1_cat2 = build_b_record(
+            "09876543210",
+            "Cat Two Item".ljust(25),
+            "654321",
+            "000100",
+            "01",
+            "000100",
+            "00010",
+            "00109",
+        )
+        a2 = build_a_record("VENDOR", "0000000202", "012500", "0000100000")
+        b2_cat2 = build_b_record(
+            "09876543210",
+            "Cat Two Item".ljust(25),
+            "654321",
+            "000100",
+            "01",
+            "000100",
+            "00010",
+            "00109",
+        )
+        input_file = tmp_path / name
+        input_file.write_text(a1 + b1_cat1 + b1_cat2 + a2 + b2_cat2, encoding="utf-8")
+        return str(input_file)
+
+    @staticmethod
+    def _upc_dict():
+        """vendor_item -> (category, upc_each, upc_case, upc_pack, ...)."""
+        return {
+            123456: ("cat1", "01234567890", "", "", ""),
+            654321: ("cat2", "09876543210", "", "", ""),
+        }
+
+    def _build_filter_processor(self):
+        backend = _SnapshotBackend()
+        send_manager = SendManager(backends={"mock": backend})
+        processor = FileProcessor(
+            send_manager=send_manager,
+            error_handler=MagicMock(spec=ErrorHandlerInterface),
+            splitter_step=EDISplitterStep(),
+        )
+        return processor, backend
+
+    def test_category_filter_without_split_uses_upc_lookup(self, tmp_path):
+        """split_edi=False + include filter sends the UPC-filtered copy."""
+        input_file = self._write_category_input(tmp_path)
+        processor, backend = self._build_filter_processor()
+
+        folder = {
+            "id": 4,
+            "alias": "filter-include",
+            "folder_name": str(tmp_path),
+            "split_edi": False,
+            "split_edi_filter_categories": "cat1",
+            "split_edi_filter_mode": "include",
+        }
+        result = processor.process_file(
+            file_path=input_file,
+            folder=folder,
+            upc_dict=self._upc_dict(),
+            run_log=None,
+        )
+
+        assert (
+            result.sent is True
+        ), f"expected filtered file sent, errors: {result.errors}"
+        assert len(backend.snapshots) == 1, backend.snapshots
+        sent_path, content = backend.snapshots[0]
+        assert sent_path != input_file, "filtered copy must be sent, not the original"
+        text = content.decode("utf-8")
+        # Invoice 1 keeps its cat1 line item and drops the cat2 one.
+        assert "0000000101" in text
+        assert "123456" in text
+        assert "654321" not in text
+        # Invoice 2 has no remaining line items and is dropped entirely.
+        assert "0000000202" not in text
+
+    def test_category_filter_exclude_mode_without_split(self, tmp_path):
+        """split_edi=False + exclude filter removes the matching category."""
+        input_file = self._write_category_input(tmp_path)
+        processor, backend = self._build_filter_processor()
+
+        folder = {
+            "id": 5,
+            "alias": "filter-exclude",
+            "folder_name": str(tmp_path),
+            "split_edi": False,
+            "split_edi_filter_categories": "cat1",
+            "split_edi_filter_mode": "exclude",
+        }
+        result = processor.process_file(
+            file_path=input_file,
+            folder=folder,
+            upc_dict=self._upc_dict(),
+            run_log=None,
+        )
+
+        assert (
+            result.sent is True
+        ), f"expected filtered file sent, errors: {result.errors}"
+        assert len(backend.snapshots) == 1, backend.snapshots
+        sent_path, content = backend.snapshots[0]
+        assert sent_path != input_file, "filtered copy must be sent, not the original"
+        text = content.decode("utf-8")
+        # Invoice 1 drops its cat1 line item but keeps the cat2 one.
+        assert "0000000101" in text
+        assert "654321" in text
+        assert "123456" not in text
+        # Invoice 2 (cat2 only) is fully retained.
+        assert "0000000202" in text
+
+    # --- Splitting combined with category filtering ------------------------
+
+    @staticmethod
+    def _make_b_record(vendor_item: str) -> str:
+        """Build a B record line for the given 6-digit vendor item."""
+        from core.edi.edi_parser import build_b_record
+
+        return build_b_record(
+            "01234567890",
+            "Cat Item".ljust(25),
+            vendor_item,
+            "000100",
+            "01",
+            "000100",
+            "00010",
+            "00109",
+        )
+
+    def _write_split_category_input(self, tmp_path, name="split_filter.edi"):
+        """Three invoices: inv1 has cat1+cat2 items, inv2 only cat2, inv3 only cat1."""
+        from core.edi.edi_parser import build_a_record
+
+        a1 = build_a_record("VENDOR", "0000000101", "012500", "0000100000")
+        a2 = build_a_record("VENDOR", "0000000202", "012500", "0000100000")
+        a3 = build_a_record("VENDOR", "0000000303", "012500", "0000100000")
+        input_file = tmp_path / name
+        input_file.write_text(
+            a1
+            + self._make_b_record("123456")
+            + self._make_b_record("654321")
+            + a2
+            + self._make_b_record("654321")
+            + a3
+            + self._make_b_record("123456"),
+            encoding="utf-8",
+        )
+        return str(input_file)
+
+    def test_split_with_category_filter_filters_each_split_file(self, tmp_path):
+        """split_edi=True + include filter: each split output keeps only matching items."""
+        input_file = self._write_split_category_input(tmp_path)
+        processor, backend = self._build_processor(backend=_SnapshotBackend())
+
+        folder = {
+            "id": 6,
+            "alias": "split-filter",
+            "folder_name": str(tmp_path),
+            "split_edi": True,
+            "split_edi_filter_categories": "cat1",
+            "split_edi_filter_mode": "include",
+        }
+        result = processor.process_file(
+            file_path=input_file,
+            folder=folder,
+            upc_dict=self._upc_dict(),
+            run_log=None,
+        )
+
+        assert (
+            result.sent is True
+        ), f"expected split files sent, errors: {result.errors}"
+        sent_paths = [path for path, _ in backend.snapshots]
+        assert len(sent_paths) == 2, backend.snapshots
+        assert input_file not in sent_paths, "original must not be sent"
+        texts = [content.decode("utf-8") for _, content in backend.snapshots]
+        # Invoice 2 has no surviving cat1 line item, so it is dropped entirely.
+        assert all("0000000202" not in text for text in texts), texts
+        for text in texts:
+            a_records = [ln for ln in text.splitlines() if ln.startswith("A")]
+            assert len(a_records) == 1, f"expected one invoice per split file: {text}"
+            # Each split output retains only the cat1 line item.
+            assert "123456" in text
+            assert "654321" not in text
+        # The two surviving invoices arrive as distinct filtered outputs.
+        assert any("0000000101" in t for t in texts), texts
+        assert any("0000000303" in t for t in texts), texts
+
+
+class _SnapshotBackend(MockBackend):
+    """MockBackend that also snapshots file contents at send time."""
+
+    def __init__(self):
+        super().__init__()
+        self.snapshots: list[tuple[str, bytes]] = []
+
+    def send(self, params, settings, filename):
+        super().send(params, settings, filename)
+        with open(filename, "rb") as f:
+            self.snapshots.append((filename, f.read()))
+
+
+class _RecordingConverter:
+    """Converter stub that records its inputs and emits a .csv copy."""
+
+    def __init__(self):
+        self.inputs: list[str] = []
+
+    def execute(self, file_path, folder, settings, upc_dict, context=None):
+        self.inputs.append(file_path)
+        converted = file_path + ".csv"
+        with open(converted, "w", encoding="utf-8") as f:
+            f.write("converted")
+        return converted
 
 
 class TestSendFile:
@@ -563,6 +963,36 @@ class TestSendFile:
         send_manager.get_enabled_backends.return_value = {"copy"}
         send_manager.send_all.return_value = {"copy": False}
         send_manager.errors = {"copy": "Connection failed"}
+
+        error_handler = MagicMock(spec=ErrorHandlerInterface)
+        processor = FileProcessor(send_manager, error_handler)
+
+        result = FileResult(file_name="test.edi", checksum="")
+        context = ProcessingContext(
+            folder={},
+            effective_folder={},
+            settings={},
+            upc_dict={},
+        )
+
+        processor._send_file(
+            current_file="/path/to/file.edi",
+            file_path="/path/to/file.edi",
+            file_basename="file.edi",
+            context=context,
+            result=result,
+            run_log=None,
+        )
+
+        assert result.sent is False
+        assert "Connection failed" in result.errors
+
+    def test_send_partial_failure(self):
+        """A single failed backend marks the whole send as failed."""
+        send_manager = MagicMock(spec=SendManager)
+        send_manager.get_enabled_backends.return_value = {"copy1", "copy2"}
+        send_manager.send_all.return_value = {"copy1": True, "copy2": False}
+        send_manager.errors = {"copy2": "Connection failed"}
 
         error_handler = MagicMock(spec=ErrorHandlerInterface)
         processor = FileProcessor(send_manager, error_handler)

--- a/tests/unit/dispatch_tests/test_pipeline_splitter.py
+++ b/tests/unit/dispatch_tests/test_pipeline_splitter.py
@@ -951,7 +951,7 @@ class TestNormalizationHelpers:
 class TestExecuteWrapper:
     """Tests for EDISplitterStep.execute wrapper behavior."""
 
-    def test_execute_returns_output_paths_from_split_result(self):
+    def test_execute_returns_output_paths_from_split_result(self, tmp_path):
         """Execute maps SplitterResult tuples to a flat list of output paths."""
         step = EDISplitterStep(splitter=MockEDISplitter())
 
@@ -965,12 +965,14 @@ class TestExecuteWrapper:
                 ]
             ),
         ) as mock_split:
-            result = step.execute("/input/source.edi", {"upc_dict": {"1": "x"}})
+            result = step.execute(
+                "/input/source.edi", {"upc_dict": {"1": "x"}}, output_dir=str(tmp_path)
+            )
 
         assert result == ["/out/one.edi", "/out/two.edi"]
         mock_split.assert_called_once()
 
-    def test_execute_defaults_upc_dict_to_empty_dict(self):
+    def test_execute_defaults_upc_dict_to_empty_dict(self, tmp_path):
         """Execute uses an empty UPC dict when folder config does not provide one."""
         step = EDISplitterStep(splitter=MockEDISplitter())
 
@@ -979,7 +981,7 @@ class TestExecuteWrapper:
             "split",
             return_value=SplitterResult(files=[("/out/only.edi", "", "")]),
         ) as mock_split:
-            step.execute("/input/source.edi", {})
+            step.execute("/input/source.edi", {}, output_dir=str(tmp_path))
 
         call_args = mock_split.call_args.args
         assert call_args[3] == {}


### PR DESCRIPTION
## What

The production pipeline sent the **original unsplit file** when `split_edi` was enabled. `EDISplitterStep.execute()` wrote split outputs into a `TemporaryDirectory` it owned, deleted them before returning, and `FileProcessor._run_splitting` discarded the return value — so recipients got the wrong granularity and it was recorded as success. The correct split-aware flow existed only in dead code.

## Changes

- `FileProcessor` now drives splitting with a caller-owned temp dir (tracked on the processing context, cleaned up by the existing artifact cleanup) and **converts + sends each split file** through the normal send path.
- UPC dictionary is threaded into the splitter, making category filtering actually work — including the filter-without-split case, which previously sent the unfiltered original.
- `EDISplitterStep.execute()` is a compat shim that no longer deletes its outputs.
- Pipeline imports in `file_processor.py` stay function-local to avoid reintroducing a module-level import cycle.

## Tests

End-to-end tests run a real `EDISplitterStep` through `FileProcessor.process_file` with a snapshot backend asserting the delivered bytes are the split (and category-filtered) outputs — the original never reaches a backend. Verified with mutation testing: breaking UPC threading or temp-dir tracking makes every new e2e test fail.

**2,506 passed, 0 failures** across the dispatch unit + integration suites; ruff clean; no new mypy errors.