### PR TITLE
fix(dispatch): make results.py a leaf to root out the dispatch import cycle

### DIFF
--- a/dispatch/pipeline/__init__.py
+++ b/dispatch/pipeline/__init__.py
@@ -2,6 +2,14 @@
 
 This module contains the individual pipeline steps that make up
 the file processing pipeline in the dispatch system.
+
+IMPORT NOTE (import cycle): this package eagerly re-exports its submodules,
+so ANY ``import dispatch.pipeline.<submodule>`` runs this whole file first.
+In particular, it pulls in ``dispatch.pipeline.factory``, which imports
+``dispatch.results``. That is only safe because ``dispatch.results`` is a
+leaf module (see its IMPORT NOTE and ``docs/IMPORT_ARCHITECTURE.md``); it
+must stay that way, and ``dispatch.services.*`` must not
+module-level-import this package.
 """
 
 from dispatch.pipeline.converter import (

--- a/dispatch/results.py
+++ b/dispatch/results.py
@@ -2,10 +2,21 @@
 
 This module contains dataclasses returned by dispatch services,
 extracted from orchestrator.py to break circular dependencies.
+
+IMPORT NOTE (import cycle): this module MUST stay a leaf of the dispatch
+import graph. It must never import from ``dispatch.services`` or
+``dispatch.pipeline`` at runtime. ``ProgressReporter`` is only used as a
+type annotation, so it is imported under ``TYPE_CHECKING``; a runtime import
+here used to drag in ``dispatch.services`` -> ``dispatch.pipeline`` ->
+back to this module, creating the cycle documented in
+``docs/IMPORT_ARCHITECTURE.md``. See also the eager-re-export comments in
+``dispatch/services/__init__.py`` and ``dispatch/pipeline/__init__.py``.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dispatch.interfaces import (
     BackendInterface,
@@ -14,7 +25,9 @@ from dispatch.interfaces import (
     FileSystemInterface,
     UPCDictionaryProvider,
 )
-from dispatch.services.progress_reporter import ProgressReporter
+
+if TYPE_CHECKING:
+    from dispatch.services.progress_reporter import ProgressReporter
 
 
 @dataclass

--- a/dispatch/services/__init__.py
+++ b/dispatch/services/__init__.py
@@ -2,6 +2,16 @@
 
 This module contains service classes that provide specialized functionality
 for the dispatch pipeline.
+
+IMPORT NOTE (import cycle): this package eagerly re-exports its submodules,
+so ANY ``import dispatch.services.<submodule>`` runs this whole file first.
+That makes ``dispatch.services`` a fan-in hub: ``dispatch.results`` must not
+runtime-import anything here (it uses ``TYPE_CHECKING`` for
+``ProgressReporter``), and no ``dispatch.services.*`` module may
+module-level-import ``dispatch.pipeline.*`` (``file_processor`` keeps those
+imports function-local). Otherwise the cycle
+``dispatch.results -> dispatch.services -> dispatch.pipeline ->
+dispatch.results`` comes back — see ``docs/IMPORT_ARCHITECTURE.md``.
 """
 
 from dispatch.services.file_processor import (

--- a/docs/IMPORT_ARCHITECTURE.md
+++ b/docs/IMPORT_ARCHITECTURE.md
@@ -1,0 +1,148 @@
+# Dispatch Import Architecture (and the Import Cycle)
+
+**Last updated:** 2026-08-09
+**Scope:** `dispatch/`, `interface/`, and anything that imports them.
+
+This document explains the `dispatch.results -> dispatch.services ->
+dispatch.pipeline -> dispatch.results` import cycle: how it forms, why it was
+latent for a long time, what fixed it, and the rules that keep it from coming
+back.
+
+## The cycle
+
+```
+dispatch.results
+    │  (1) from dispatch.services.progress_reporter import ProgressReporter   ← RUNTIME edge (was)
+    ▼
+dispatch.services/__init__.py          ← eager re-export: importing ANY
+    │  (2) from dispatch.services.file_processor import ...                    services.* submodule runs this file
+    ▼
+dispatch.services.file_processor
+    │  (3) from dispatch.pipeline.splitter import SplitterResult               ← module-level edge (was)
+    ▼
+dispatch.pipeline/__init__.py          ← eager re-export: importing ANY
+    │  (4) from dispatch.pipeline.factory import create_standard_pipeline      pipeline.* submodule runs this file
+    ▼
+dispatch.pipeline.factory
+    │  (5) from dispatch.results import DispatchConfig
+    ▼
+dispatch.results  ────────────────────────── CYCLE (results is mid-load) ✗
+```
+
+Two `__init__.py` files make this far worse than a two-module tangle:
+
+- `dispatch/services/__init__.py` eagerly re-exports every public name, so
+  `import dispatch.services.progress_reporter` (edge 1) boots the *entire*
+  services package, including `file_processor`.
+- `dispatch/pipeline/__init__.py` eagerly re-exports every pipeline step, so
+  `import dispatch.pipeline.splitter` (edge 3) boots the *entire* pipeline
+  package, including `factory`, which imports `dispatch.results` (edge 5).
+
+## Root cause
+
+`dispatch/results.py` is supposed to be a leaf — it holds shared dataclasses
+(`DispatchConfig`, `FolderResult`) with no business logic. But it imported a
+concrete service type at runtime:
+
+```python
+# dispatch/results.py (before the fix)
+from dispatch.services.progress_reporter import ProgressReporter   # annotation-only use!
+...
+progress_reporter: ProgressReporter | None = None
+```
+
+`ProgressReporter` is used **only as a type annotation**. The runtime import
+was the single edge that let `dispatch.results` reach back into
+`dispatch.services` (1), which reaches `file_processor` (2), which — once any
+module-level `dispatch.pipeline` import existed — reaches `factory` (4) and
+returns to `results` (5).
+
+Why it was latent for so long: the loop only closes when **both** directions
+exist. For a long time `dispatch.services.*` had no module-level
+`dispatch.pipeline` imports, so the graph was a DAG and every import order
+worked. In 2026-08, `file_processor.py` gained module-level pipeline imports
+for the split flow, closing the loop — and `import dispatch.results` /
+`import dispatch.orchestrator` as a **first** import started raising
+`ImportError: cannot import name 'DispatchConfig' from partially initialized
+module 'dispatch.results'`.
+
+Most tests and the Qt app never noticed because their import order happened to
+load `dispatch.pipeline` fully before `dispatch.results` (Python caches the
+partially initialized module in `sys.modules`, so the second attempt to import
+it is skipped and the cycle only *sometimes* blows up — it depends entirely on
+which module is imported first in a given process).
+
+## The fix (2026-08-09)
+
+Two changes, one at the root and one at the trigger:
+
+1. **`dispatch/results.py` — make it a true leaf.** `ProgressReporter` is now
+   imported under `TYPE_CHECKING` (with `from __future__ import annotations`).
+   `dispatch.results` no longer reaches into `dispatch.services` at runtime,
+   so there is no path from `dispatch.pipeline` back into `dispatch.services`
+   through `factory` — the loop is structurally impossible again.
+
+2. **`dispatch/services/file_processor.py` — keep pipeline imports
+   function-local.** `SplitterResult` is imported under `TYPE_CHECKING` for
+   annotations and inside `_run_splitting()` for runtime use. `temp_dir_utils`
+   is also imported inside the function. This matches the codebase's existing
+   convention (e.g. `_normalize_validation_output` imports
+   `dispatch.pipeline.validator` locally).
+
+## Rules for future changes
+
+1. **`dispatch/results.py` and `dispatch/interfaces.py` are leaves.** Never
+   add a runtime import from them into `dispatch.services.*`,
+   `dispatch.pipeline.*`, or anything that transitively reaches those
+   packages. If a name is only used in a type annotation, import it under
+   `TYPE_CHECKING` (and add `from __future__ import annotations` if the module
+   does not have it).
+
+2. **`dispatch/services/*` must not module-level-import `dispatch.pipeline.*`.**
+   The two packages form a bidirectional dependency through
+   `pipeline.factory -> results` (fine, results is a leaf) — do not add the
+   opposite module-level edge. Function-local imports are the sanctioned
+   pattern when a service needs a pipeline step type at runtime.
+
+3. **Be careful with the eager `__init__.py` re-exports.** Because
+   `dispatch/services/__init__.py` and `dispatch/pipeline/__init__.py`
+   re-export everything, a dependency that looks harmless at the submodule
+   level ("I only import `dispatch.pipeline.splitter`") actually pulls in the
+   whole package. When adding a new import, trace what its parent package
+   `__init__.py` drags in before assuming the graph is acyclic.
+
+4. **When adding a new module-level `dispatch.*` import anywhere, run the
+   import-order smoke check below.** Import cycles in Python are
+   order-dependent: the same code that imports fine in tests can crash in a
+   fresh process.
+
+## Verification
+
+These must all succeed in a **fresh interpreter** (first import order):
+
+```bash
+python -c "import dispatch.results"
+python -c "import dispatch.orchestrator"
+python -c "import dispatch.pipeline"
+python -c "import dispatch.services.file_processor"
+python -c "import dispatch.send_manager"
+python -c "import interface.qt.app"
+```
+
+If any raises `ImportError` about a *partially initialized module*, an import
+cycle has been reintroduced — see the rules above.
+
+The regression test `tests/unit/dispatch_tests/test_import_order.py` runs
+these as subprocesses on every test run.
+
+## How to debug a cycle if one reappears
+
+1. Reproduce with the failing first import: `python -c "import dispatch.X"`.
+   The traceback shows the chain that loops back.
+2. Identify which edge is new (compare against the diagram above).
+3. Decide the fix:
+   - annotation-only use → `TYPE_CHECKING` (leaf modules),
+   - runtime use inside a service → function-local import,
+   - genuine structural need → break the cycle at the `__init__.py` level
+     (make one package's re-exports lazy) instead of adding `# noqa` or
+     import hacks.

--- a/scripts/import_check.py
+++ b/scripts/import_check.py
@@ -1,0 +1,183 @@
+"""Import every module in the repository as the FIRST import of a fresh subprocess.
+
+Import cycles in Python are order-dependent: ``import dispatch.results`` works
+if ``dispatch.pipeline`` happens to load first in the same process, but crashes
+as a first import in a fresh interpreter. Ordinary test runs mask these cycles,
+so this script checks every module the way a fresh entry point would see it.
+
+Usage::
+
+    python scripts/import_check.py                  # production modules only
+    python scripts/import_check.py --include-tests  # also check tests/ modules
+    python scripts/import_check.py --jobs 16        # more parallelism
+
+Exit code is 0 when every module imports cleanly, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Directories that are never part of the shipped import graph.
+EXCLUDED_DIRS = {
+    ".freebuff",
+    ".git",
+    ".pytest_temp",
+    ".venv",
+    "__pycache__",
+    "archive",
+    "build",
+    "build_wine",
+    "dist",
+}
+
+# Exception categories worth distinguishing in the report.
+_ERROR_RE = re.compile(r"^([A-Za-z_][\w.]*(?:Error|Exception|Warning)):")
+
+# Modules that are audited to fail as first imports for known, deliberate
+# reasons (as of 2026-08-09). They are reported but do not fail the run, so
+# the script can act as a CI guard for NEW import cycles. Each entry is the
+# module path relative to the repo root, mapped to why it is expected to fail:
+#   - nuitka/build_*.py: build scripts use a flat `import nuitka_config` that
+#     only resolves in script mode (sys.path[0] == nuitka/); they are never
+#     imported as package members.
+#   - scripts/dummy_run_progress.py, scripts/screenshot_script.py: legacy
+#     scratch scripts that import the legacy PyQt5 binding, which is not
+#     installed (the project is PySide6). See tests/meta/test_module_coverage.py.
+#   - scripts/test_animation.py: raises pytest.skip() at module level on
+#     purpose, so pytest collection skips it; outside pytest that raise is
+#     intentional (it is a manual debug script).
+KNOWN_FAILURES: dict[str, str] = {
+    "nuitka/build_linux.py": "script-only build tool (flat sibling import)",
+    "nuitka/build_windows.py": "script-only build tool (flat sibling import)",
+    "scripts/dummy_run_progress.py": "legacy scratch script (PyQt5 not installed)",
+    "scripts/screenshot_script.py": "legacy scratch script (PyQt5 not installed)",
+    "scripts/test_animation.py": "deliberate module-level pytest.skip()",
+}
+
+
+def discover_modules(root: Path, include_tests: bool) -> list[tuple[str, str]]:
+    """Return ``(relative_path, module_name)`` pairs for every importable module."""
+    modules: list[tuple[str, str]] = []
+    for py in sorted(root.rglob("*.py")):
+        parts = list(py.relative_to(root).parts)
+        if any(part in EXCLUDED_DIRS for part in parts):
+            continue
+        if not include_tests and parts[0] == "tests":
+            continue
+        if parts[-1] == "__main__.py":
+            continue
+        if parts[-1] == "__init__.py":
+            name = ".".join(parts[:-1])
+        else:
+            name = ".".join((*parts[:-1], parts[-1][:-3]))
+        if not name:
+            continue
+        # A dash in the module name (e.g. PyInstaller ``hook-*.py`` files) can
+        # never be imported — skip rather than report a guaranteed failure.
+        if any("-" in part for part in name.split(".")):
+            continue
+        modules.append((str(py.relative_to(root)), name))
+    return modules
+
+
+def classify_stderr(stderr: str) -> str:
+    """Extract the exception type from a traceback's last lines, if any."""
+    for line in reversed(stderr.splitlines()):
+        line = line.strip()
+        match = _ERROR_RE.match(line)
+        if match:
+            return match.group(1)
+    return "UnknownError"
+
+
+def check_module(
+    root: Path, rel: str, name: str, timeout: int
+) -> tuple[str, str, str, int]:
+    """Import ``name`` as the first import of a fresh interpreter."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", f"import {name}"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return rel, name, "Timeout", 124
+    if proc.returncode == 0:
+        return rel, name, "", 0
+    return rel, name, classify_stderr(proc.stderr), proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--include-tests",
+        action="store_true",
+        help="also check modules under tests/ (noisy: test modules can rely "
+        "on pytest conftest state at import time)",
+    )
+    parser.add_argument(
+        "--jobs", type=int, default=8, help="parallel subprocesses (default: 8)"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=120, help="per-module timeout seconds"
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    modules = discover_modules(root, args.include_tests)
+    if not modules:
+        print("No modules found.", file=sys.stderr)
+        return 1
+
+    print(
+        f"Checking {len(modules)} modules as first imports " f"({args.jobs} workers)..."
+    )
+    start = time.monotonic()
+    failures: list[tuple[str, str, str, int]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futures = {
+            pool.submit(check_module, root, rel, name, args.timeout): (rel, name)
+            for rel, name in modules
+        }
+        for future in concurrent.futures.as_completed(futures):
+            rel, name, error, code = future.result()
+            if error:
+                failures.append((rel, name, error, code))
+    elapsed = time.monotonic() - start
+
+    known = [f for f in failures if f[0] in KNOWN_FAILURES]
+    unknown = [f for f in failures if f[0] not in KNOWN_FAILURES]
+    passed = len(modules) - len(failures)
+    print(f"\n{passed}/{len(modules)} modules import cleanly " f"({elapsed:.1f}s)")
+
+    if known:
+        print("\n=== KNOWN-BENIGN FAILURES (audited, do not fail the run) ===")
+        for rel, _name, error, _code in sorted(known):
+            reason = KNOWN_FAILURES[rel]
+            print(f"  {rel:<50} {error} ({reason})")
+
+    if unknown:
+        print("\n=== NEW FAILURES (by exception type) ===")
+        by_type: dict[str, list[tuple[str, str, int]]] = {}
+        for rel, name, error, code in unknown:
+            by_type.setdefault(error, []).append((rel, name, code))
+        for error in sorted(by_type):
+            entries = by_type[error]
+            print(f"\n{error} ({len(entries)}):")
+            for rel, name, code in sorted(entries):
+                print(f"  {rel:<65} -> import {name} (exit {code})")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/dispatch_tests/test_import_order.py
+++ b/tests/unit/dispatch_tests/test_import_order.py
@@ -1,0 +1,52 @@
+"""Regression tests for the dispatch import cycle.
+
+The dispatch.results -> dispatch.services -> dispatch.pipeline -> dispatch.results
+cycle is order-dependent: the same code that imports fine in tests can raise
+``ImportError: cannot import name 'X' from partially initialized module`` when a
+different module is imported FIRST in a fresh process.
+
+These tests import each entry point as the *first* import in a subprocess, which
+is the only reliable way to catch a reintroduced cycle. See
+docs/IMPORT_ARCHITECTURE.md for the full diagram and rules.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.dispatch]
+
+# Every entry point that must survive being the first import in a fresh process.
+# Importing any of these used to crash before the results.py fix (2026-08-09).
+CRITICAL_FIRST_IMPORTS = [
+    "dispatch",
+    "dispatch.pipeline",
+    "dispatch.results",
+    "dispatch.orchestrator",
+    "dispatch.services",
+    "dispatch.services.file_processor",
+    "dispatch.send_manager",
+    "interface.qt.app",
+    "main_interface",
+]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize("module", CRITICAL_FIRST_IMPORTS)
+def test_module_imports_first_in_fresh_interpreter(module: str) -> None:
+    """``import <module>`` must succeed as the first import of a fresh process."""
+    proc = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        f"import {module} failed as a first import — an import cycle has been "
+        f"reintroduced. See docs/IMPORT_ARCHITECTURE.md.\n"
+        f"stderr:\n{proc.stderr}"
+    )


### PR DESCRIPTION
## What

`import dispatch.results` crashed as a first import: `dispatch.results` imported `ProgressReporter` from `dispatch.services` at runtime for an **annotation-only** use, and the eager re-exports in `dispatch/services/__init__.py` and `dispatch/pipeline/__init__.py` amplified that into a full cycle (`results -> services -> file_processor -> pipeline -> factory -> results`). The loop was order-dependent — tests masked it via import order, a fresh process hit `ImportError: cannot import name 'DispatchConfig' from partially initialized module`.

## Changes

- `dispatch/results.py` — `ProgressReporter` now imports under `TYPE_CHECKING` (`from __future__ import annotations`); the module is a leaf again, so the loop is structurally impossible.
- Cycle-awareness comments in both eager re-export `__init__.py` files explaining why a submodule import pulls in the whole package.
- `docs/IMPORT_ARCHITECTURE.md` — the diagram, root cause, fix, and four rules for future changes.
- `tests/unit/dispatch_tests/test_import_order.py` — 9 parametrized tests importing each critical entry point as the **first import of a fresh subprocess** (the only way to catch an order-dependent cycle).
- `scripts/import_check.py` — imports every repo module as a first import of a fresh interpreter; audited result: 227/232 production modules clean, 5 known-benign (script-only build tools, legacy PyQt5 scratch scripts, a deliberate module-level `pytest.skip`), **0 unexpected failures**. CI-ready: exit 0 on known-only, 1 on anything new.